### PR TITLE
Rename nvim-base16 to base16-nvim

### DIFF
--- a/modules/home/neovim/plugins/base16.nix
+++ b/modules/home/neovim/plugins/base16.nix
@@ -3,7 +3,7 @@
 {
   programs.neovim.plugins = [
     {
-      plugin = pkgs.vimPlugins.nvim-base16;
+      plugin = pkgs.vimPlugins.base16-nvim;
       type = "viml";
       config = /*vim*/ ''
         colorscheme base16-default-dark


### PR DESCRIPTION
As per https://github.com/NixOS/nixpkgs/pull/289539, the package has been renamed and needs to be updated