### PR TITLE
base: fix FHS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711006105,
-        "narHash": "sha256-pvjqjx4L2Hx/NP3RWcwLjk+ABtMODAJ9+rgreU6fP6I=",
+        "lastModified": 1711261295,
+        "narHash": "sha256-5DUNQl9BSmLxgGLbF05G7hi/UTk9DyZq8AuEszhQA7Q=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a8c966ee117c278a5aabc6f00b00ef62eb7e28f6",
+        "rev": "5d2d3e421ade554b19b4dbb0d11a04023378a330",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710974515,
-        "narHash": "sha256-jZpdsypecYTOO9l12Vy77otGmh9uz8tGzcguifA30Vs=",
+        "lastModified": 1711133180,
+        "narHash": "sha256-WJOahf+6115+GMl3wUfURu8fszuNeJLv9qAWFQl3Vmo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1c2acec99933f9835cc7ad47e35303de92d923a4",
+        "rev": "1c2c5e4cabba4c43504ef0f8cc3f3dfa284e2dbb",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710806803,
-        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
+        "lastModified": 1711163522,
+        "narHash": "sha256-YN/Ciidm+A0fmJPWlHBGvVkcarYWSC+s3NTPk/P+q3c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
+        "rev": "44d0940ea560dee511026a53f0e2e2cde489b4d4",
         "type": "github"
       },
       "original": {

--- a/modules/profiles/fhs.nix
+++ b/modules/profiles/fhs.nix
@@ -1,6 +1,8 @@
 { lib, ... }:
 
 {
+  system.activationScripts.binsh = lib.mkForce ""; # obsolete
+
   system.activationScripts.usrbinenv = lib.mkForce /*bash*/ ''
     function copyLinks() {
       src=$1
@@ -14,7 +16,8 @@
         fi
       done
     }
-    copyLinks /run/current-system/sw/bin /bin /usr/bin /usr/local/bin
-    copyLinks /run/current-system/sw/lib /lib /lib64
+    sw=/nix/var/nix/gcroots/current-system/sw
+    copyLinks $sw/bin /bin /usr/bin /usr/local/bin
+    copyLinks $sw/lib /lib /lib64
   '';
 }

--- a/trilby-cli/flake.lock
+++ b/trilby-cli/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710806803,
-        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
+        "lastModified": 1711163522,
+        "narHash": "sha256-YN/Ciidm+A0fmJPWlHBGvVkcarYWSC+s3NTPk/P+q3c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
+        "rev": "44d0940ea560dee511026a53f0e2e2cde489b4d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The directory `/run/current-system/sw/bin` sometimes does not exist by the time our FHS activation script runs, which causes it to be linked instead of copied.

This then breaks the `binsh` activation script, which exists only to create `/bin/sh`.

- The `/run/current-system/sw` directory itself is just a link that is created at system activation, so we can instead use the `current-system` gcroot it points to. The gcroot directory will always exist, so we have one level of indirection less.
- The `binsh` script is not needed, because the `current-system` already contains `/bin/sh`.