### PR TITLE
trilby-cli: set profile on update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711261295,
-        "narHash": "sha256-5DUNQl9BSmLxgGLbF05G7hi/UTk9DyZq8AuEszhQA7Q=",
+        "lastModified": 1712356478,
+        "narHash": "sha256-kTcEtrQIRnexu5lAbLsmUcfR2CrmsACF1s3ZFw1NEVA=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5d2d3e421ade554b19b4dbb0d11a04023378a330",
+        "rev": "0a17298c0d96190ef3be729d594ba202b9c53beb",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711133180,
-        "narHash": "sha256-WJOahf+6115+GMl3wUfURu8fszuNeJLv9qAWFQl3Vmo=",
+        "lastModified": 1712390667,
+        "narHash": "sha256-ebq+fJZfobqpsAdGDGpxNWSySbQejRwW9cdiil6krCo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1c2c5e4cabba4c43504ef0f8cc3f3dfa284e2dbb",
+        "rev": "b787726a8413e11b074cde42704b4af32d95545c",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711163522,
-        "narHash": "sha256-YN/Ciidm+A0fmJPWlHBGvVkcarYWSC+s3NTPk/P+q3c=",
+        "lastModified": 1712163089,
+        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "44d0940ea560dee511026a53f0e2e2cde489b4d4",
+        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
         "type": "github"
       },
       "original": {

--- a/modules/profiles/fhs.nix
+++ b/modules/profiles/fhs.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ trilby, lib, pkgs, ... }:
 
 {
   system.activationScripts.binsh = lib.mkForce ""; # obsolete
@@ -16,8 +16,14 @@
         fi
       done
     }
-    sw=/nix/var/nix/gcroots/current-system/sw
+    sw=/run/current-system/sw
     copyLinks $sw/bin /bin /usr/bin /usr/local/bin
     copyLinks $sw/lib /lib /lib64
   '';
+}
+// lib.optionalAttrs (lib.versionAtLeast trilby.release "24.05") {
+  environment = {
+    ldso = "${pkgs.stdenv.cc.libc_lib}/lib64/ld-linux-x86-64.so.2";
+    ldso32 = "${pkgs.stdenv.cc.libc_lib}/lib/ld-linux-x86-64.so.2";
+  };
 }

--- a/trilby-cli/CHANGELOG.md
+++ b/trilby-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for trilby-cli
 
+## 24.4.0 -- 2024-04-04
+
+* Introduce [CalVer](https://calver.org/) versioning (YY.MM.MICRO)
+* Add `--version` flag
 ## 0.1.0.0 -- YYYY-mm-dd
 
 * First version. Released on an unsuspecting world.

--- a/trilby-cli/CHANGELOG.md
+++ b/trilby-cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Introduce [CalVer](https://calver.org/) versioning (YY.MM.MICRO)
 * Add `--version` flag
+* Replace `--verbosity` with `--quiet`, `--verbose`, and `--debug`
 ## 0.1.0.0 -- YYYY-mm-dd
 
 * First version. Released on an unsuspecting world.

--- a/trilby-cli/CHANGELOG.md
+++ b/trilby-cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 24.4.0 -- 2024-04-04
 
+* Set profile on update
 * Introduce [CalVer](https://calver.org/) versioning (YY.MM.MICRO)
 * Add `--version` flag
 * Replace `--verbosity` with `--quiet`, `--verbose`, and `--debug`

--- a/trilby-cli/CHANGELOG.md
+++ b/trilby-cli/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Introduce [CalVer](https://calver.org/) versioning (YY.MM.MICRO)
 * Add `--version` flag
 * Replace `--verbosity` with `--quiet`, `--verbose`, and `--debug`
+* Drop direct dependency on `terminal`
+
 ## 0.1.0.0 -- YYYY-mm-dd
 
 * First version. Released on an unsuspecting world.

--- a/trilby-cli/app/Main.hs
+++ b/trilby-cli/app/Main.hs
@@ -1,14 +1,11 @@
 module Main where
 
-import Control.Monad.Logger
-import Data.Maybe (fromMaybe)
-import Log (withLog)
-import Options.Applicative (execParser, (<|>))
-import System.Environment (lookupEnv)
+import Options.Applicative (execParser)
 import Trilby.App
 import Trilby.Command
 import Trilby.Install (install)
 import Trilby.Install.Options (validateParsedInstallOpts)
+import Trilby.Log (withLog)
 import Trilby.Options
 import Trilby.Update (update)
 import Prelude
@@ -16,10 +13,8 @@ import Prelude
 main :: IO ()
 main = do
     opts <- execParser parseOptionsInfo
-    state <- do
-        defaultVerbosity <- (readLogLevel =<<) <$> lookupEnv "TRILBY_VERBOSITY"
-        let verbosity = fromMaybe LevelWarn $ opts.verbosity <|> defaultVerbosity
-        pure AppState{..}
+    verbosity <- getVerbosity opts
+    let state = AppState{..}
     withLog state.verbosity do
         runApp state do
             case opts.command of

--- a/trilby-cli/flake.lock
+++ b/trilby-cli/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711163522,
-        "narHash": "sha256-YN/Ciidm+A0fmJPWlHBGvVkcarYWSC+s3NTPk/P+q3c=",
+        "lastModified": 1712163089,
+        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "44d0940ea560dee511026a53f0e2e2cde489b4d4",
+        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         "text-rope-zipper": "text-rope-zipper"
       },
       "locked": {
-        "lastModified": 1708535983,
-        "narHash": "sha256-8CMmFbVZKpqWlri6jEMNy+3yVcApvv2FBVgPHCPl/dw=",
+        "lastModified": 1712401643,
+        "narHash": "sha256-mOW8LmyA5J77K6ODHVsZ+gYJhqAS6ZeCijOHYivJEig=",
         "owner": "ners",
         "repo": "terminal-widgets",
-        "rev": "5a60a216137ccb5237d50d60c656e618acdd3218",
+        "rev": "de1a35d9b56b4677e2b003e45ef9fcfba2827de4",
         "type": "github"
       },
       "original": {

--- a/trilby-cli/flake.nix
+++ b/trilby-cli/flake.nix
@@ -35,9 +35,9 @@
       pname = "trilby-cli";
       src = hsSrc ./.;
       ghcs = [ "ghc94" "ghc96" ];
-      overlay = final: prev: lib.pipe prev [
-        (inputs.terminal-widgets.overlays.default final)
-        (prev: {
+      overlay = lib.composeManyExtensions [
+        inputs.terminal-widgets.overlays.default
+        (final: prev: {
           haskell = prev.haskell // {
             packageOverrides = lib.composeExtensions
               prev.haskell.packageOverrides

--- a/trilby-cli/src/Trilby/Command.hs
+++ b/trilby-cli/src/Trilby/Command.hs
@@ -14,7 +14,7 @@ parseCommand :: Parser (Command Maybe)
 parseCommand = hsubparser (parseUpdate <> parseInstall)
 
 parseInstall :: Mod CommandFields (Command Maybe)
-parseInstall = command "install" $ info (Install <$> parseInstallOpts optional) (progDesc "install Trilby")
+parseInstall = command "install" $ info (Install <$> parseInstallOpts optional) (progDesc "Install Trilby")
 
 parseUpdate :: Mod CommandFields (Command Maybe)
-parseUpdate = command "update" $ info (Update <$> parseUpdateOpts optional) (progDesc "update Trilby")
+parseUpdate = command "update" $ info (Update <$> parseUpdateOpts optional) (progDesc "Update Trilby")

--- a/trilby-cli/src/Trilby/Log.hs
+++ b/trilby-cli/src/Trilby/Log.hs
@@ -1,14 +1,11 @@
-module Log where
+module Trilby.Log where
 
 import Control.Monad.Logger
 import Data.List qualified as List
-import Data.String (IsString (fromString))
-import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Text.IO qualified as Text
 import System.Console.ANSI
-import System.IO (stderr)
 import Prelude
 
 locStr :: (IsString a) => Loc -> a

--- a/trilby-cli/src/Trilby/Options.hs
+++ b/trilby-cli/src/Trilby/Options.hs
@@ -2,6 +2,7 @@ module Trilby.Options where
 
 import Options.Applicative hiding (command)
 import Trilby.Command (Command, parseCommand)
+import Trilby.Version qualified as Trilby
 import Prelude
 
 data Options m = Options
@@ -33,6 +34,7 @@ parseOptions = do
                 (long "verbosity" <> metavar "LOGLEVEL" <> help "output verbosity")
                 [LevelDebug, LevelInfo, LevelWarn, LevelError]
     command <- parseCommand
+    simpleVersioner $ unwords [Trilby.name, Trilby.version]
     pure Options{..}
 
 parseOptionsInfo :: ParserInfo (Options Maybe)

--- a/trilby-cli/src/Trilby/Version.hs
+++ b/trilby-cli/src/Trilby/Version.hs
@@ -1,0 +1,25 @@
+module Trilby.Version where
+
+import Data.FileEmbed
+import Data.List qualified as List
+import Data.Text qualified as Text
+import Prelude
+
+cabalFile :: (IsString s) => s
+cabalFile = $(embedStringFile "trilby-cli.cabal")
+
+cabalField :: (IsString s) => Text -> s
+cabalField ((<> ":") -> field) =
+    fromString
+        . Text.unpack
+        . List.head
+        . List.tail
+        . List.dropWhile (/= field)
+        . Text.words
+        $ cabalFile
+
+name :: (IsString s) => s
+name = cabalField "name"
+
+version :: (IsString s) => s
+version = cabalField "version"

--- a/trilby-cli/src/Trilby/Widgets.hs
+++ b/trilby-cli/src/Trilby/Widgets.hs
@@ -1,22 +1,18 @@
 module Trilby.Widgets where
 
 import Data.Text.Rope.Zipper qualified as RopeZipper
-import System.Terminal
 import System.Terminal.Widgets.Buttons
-import System.Terminal.Widgets.Common qualified as Terminal
+import System.Terminal.Widgets.Common (runWidgetIO)
 import System.Terminal.Widgets.SearchSelect
 import System.Terminal.Widgets.Select
 import System.Terminal.Widgets.TextInput
 import Prelude
 
-runWidget :: (Terminal.Widget w) => w -> App w
-runWidget = liftIO . withTerminal . runTerminalT . Terminal.runWidget
-
 textInput :: Text -> Text -> App Text
 textInput ((<> " ") -> prompt) (RopeZipper.fromText -> value) = do
     $(logDebug) prompt
     text <-
-        runWidget
+        runWidgetIO
             TextInput
                 { prompt
                 , value
@@ -30,7 +26,7 @@ passwordInput :: Text -> App Text
 passwordInput ((<> " ") -> prompt) = do
     $(logDebug) prompt
     let getPw :: TextInput -> App Text
-        getPw = fmap (RopeZipper.toText . (.value)) . runWidget
+        getPw = fmap (RopeZipper.toText . (.value)) . runWidgetIO
     let input =
             TextInput
                 { prompt
@@ -51,7 +47,7 @@ buttons :: (Eq a, Show a) => Text -> [(a, Char)] -> Int -> (a -> Text) -> App a
 buttons prompt values selected buttonText = do
     $(logDebug) prompt
     b <-
-        runWidget
+        runWidgetIO
             Buttons
                 { prompt
                 , buttons = [(buttonText s, Just c) | (s, c) <- values]
@@ -77,7 +73,7 @@ select prompt values defaultValue optionText
     | null values = errorExit "select: called with no options and no default value"
     | otherwise = do
         selectedValues <-
-            runWidget
+            runWidgetIO
                 Select
                     { prompt
                     , options =
@@ -106,7 +102,7 @@ searchSelect :: (Eq a, Show a) => Text -> [a] -> [a] -> (a -> Text) -> App [a]
 searchSelect ((<> " ") -> prompt) values defaultValues optionText
     | length values < 2 = pure defaultValues
     | otherwise =
-        runWidget
+        runWidgetIO
             SearchSelect
                 { prompt
                 , searchValue = ""

--- a/trilby-cli/trilby-cli.cabal
+++ b/trilby-cli/trilby-cli.cabal
@@ -87,7 +87,6 @@ library
         , mtl
         , optparse-applicative
         , process
-        , terminal
         , terminal-widgets
         , text
         , text-rope-zipper

--- a/trilby-cli/trilby-cli.cabal
+++ b/trilby-cli/trilby-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.4
 name:            trilby-cli
-version:         0.1.0.0
+version:         24.4.0
 synopsis:        Trilby command line tools
 homepage:        https://github.com/ners/trilby
 license:         Apache-2.0
@@ -70,11 +70,13 @@ library
         Trilby.Options
         Trilby.Update
         Trilby.Update.Options
+        Trilby.Version
     build-depends:
         , base
         , data-default
         , data-fix
         , extra
+        , file-embed
         , generic-lens
         , hnix
         , lens

--- a/trilby-cli/trilby-cli.cabal
+++ b/trilby-cli/trilby-cli.cabal
@@ -67,11 +67,13 @@ library
         Trilby.Install.Disko
         Trilby.Install.Flake
         Trilby.Install.Options
+        Trilby.Log
         Trilby.Options
         Trilby.Update
         Trilby.Update.Options
         Trilby.Version
     build-depends:
+        , ansi-terminal
         , base
         , data-default
         , data-fix
@@ -97,12 +99,7 @@ executable trilby
     import:         common
     main-is:        Main.hs
     hs-source-dirs: app
-    other-modules:
-        Log,
     build-depends:
-        , ansi-terminal
         , base
-        , monad-logger
         , optparse-applicative
-        , text
         , trilby-cli


### PR DESCRIPTION
`trilby-cli` does not correctly set profile when updating.

The fix is modeled after `nixos-rebuild`:
https://github.com/NixOS/nixpkgs/blob/228dc7eaf4252f1c95a3c5e639a170e3ba693d93/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh#L707

We also introduce [CalVer](https://calver.org/) and a `--version` flag.