### PR TITLE
Remove treesitter-context as default plugin

### DIFF
--- a/modules/home/neovim/plugins/treesitter/default.nix
+++ b/modules/home/neovim/plugins/treesitter/default.nix
@@ -10,12 +10,5 @@
     rainbow-delimiters-nvim
     nvim-treesitter-textobjects
     nvim-treesitter-refactor
-    {
-      plugin = nvim-treesitter-context;
-      type = "lua";
-      config = /*lua*/ ''
-        require('treesitter-context').setup({})
-      '';
-    }
   ];
 }


### PR DESCRIPTION
Treesitter-context behaves pathologically with certain languages so should be left to the user to include if desired.