### PR TITLE
Allow passing extraSpecialArgs to home-manager config

### DIFF
--- a/lib/trilby.nix
+++ b/lib/trilby.nix
@@ -155,6 +155,7 @@ rec {
       {
         users.users.${user.name} = user;
         home-manager.users.${user.name} = home;
+        home-manager.extraSpecialArgs = u.extraSpecialArgs or {};
       }
       (lib.optionalAttrs isNixos {
         users.groups.${user.name} = group;


### PR DESCRIPTION
This allows passing `extraSpecialArgs` to the `trilbyUser` config which enables passing in extra inputs to home-manager modules.


e.g.

```nix
lib.trilbyUser trilby {
    name = "user";
    extraSpecialArgs = { inherit hyprland; };
}
```