### PR TITLE
Update nix-direnv overlay

### DIFF
--- a/modules/overlays/nix-direnv/default.nix
+++ b/modules/overlays/nix-direnv/default.nix
@@ -5,17 +5,19 @@ if unstable then
   {
     nix-direnv = prev.nix-direnv.override {
       resholve = prev.resholve // {
-        mkDerivation = attrs: prev.resholve.mkDerivation (attrs // {
-          patches = (attrs.patches or [ ]) ++ [
-            ./nvd.patch
-          ];
-          solutions = prev.lib.recursiveUpdate attrs.solutions {
-            default = {
-              inputs = with final; [ findutils nvd ] ++ attrs.solutions.default.inputs or [ ];
-              execer = [ "cannot:${final.nvd}/bin/nvd" ] ++ attrs.solutions.default.execer or [ ];
+        mkDerivation = f: prev.resholve.mkDerivation (finalAttrs:
+          let attrs = f finalAttrs;
+          in attrs // {
+            patches = (attrs.patches or [ ]) ++ [
+              ./nvd.patch
+            ];
+            solutions = prev.lib.recursiveUpdate attrs.solutions {
+              default = {
+                inputs = with final; [ findutils nvd ] ++ attrs.solutions.default.inputs or [ ];
+                execer = [ "cannot:${final.nvd}/bin/nvd" ] ++ attrs.solutions.default.execer or [ ];
+              };
             };
-          };
-        });
+          });
       };
     };
   }


### PR DESCRIPTION
The nix-direnv package changed the resholve invocation to take a lambda instead of a recursive attrset, causing the trilby overlay to fail to build. This small change updates it to not break.